### PR TITLE
Add Starter Packs Feature

### DIFF
--- a/src/components/StarterPackCard.tsx
+++ b/src/components/StarterPackCard.tsx
@@ -1,0 +1,198 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Users, UserPlus, Check } from "lucide-react";
+import { type StarterPack } from "@/hooks/useStarterPacks";
+import { useAuthor } from "@/hooks/useAuthor";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { useQuery } from "@tanstack/react-query";
+import { useNostr } from "@nostrify/react";
+import { useState } from "react";
+import { genUserName } from "@/lib/genUserName";
+
+interface ProfilePreviewProps {
+  pubkey: string;
+  petname?: string;
+}
+
+function ProfilePreview({ pubkey, petname }: ProfilePreviewProps) {
+  const author = useAuthor(pubkey);
+  const metadata = author.data?.metadata;
+
+  const displayName = petname || metadata?.name || metadata?.display_name || genUserName(pubkey);
+  const avatarUrl = metadata?.picture;
+
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <Avatar className="h-8 w-8 flex-shrink-0">
+        <AvatarImage src={avatarUrl} alt={displayName} />
+        <AvatarFallback className="text-xs">
+          {displayName.slice(0, 2).toUpperCase()}
+        </AvatarFallback>
+      </Avatar>
+      <span className="text-sm truncate">{displayName}</span>
+    </div>
+  );
+}
+
+interface StarterPackCardProps {
+  pack: StarterPack;
+}
+
+export function StarterPackCard({ pack }: StarterPackCardProps) {
+  const { user } = useCurrentUser();
+  const { nostr } = useNostr();
+  const { mutate: publish, isPending: isPublishing } = useNostrPublish();
+  const [isFollowing, setIsFollowing] = useState(false);
+
+  // Get current user's follow list (kind 3)
+  const { data: followList } = useQuery({
+    queryKey: ['follow-list', user?.pubkey],
+    queryFn: async ({ signal }) => {
+      if (!user?.pubkey) return null;
+      
+      const [event] = await nostr.query(
+        [{ kinds: [3], authors: [user.pubkey], limit: 1 }],
+        { signal: AbortSignal.any([signal, AbortSignal.timeout(1500)]) }
+      );
+      
+      return event;
+    },
+    enabled: !!user?.pubkey,
+    staleTime: 60 * 1000, // 1 minute
+  });
+
+  // Check if already following these profiles
+  const currentFollows = followList?.tags.filter(([name]) => name === 'p').map(([, pubkey]) => pubkey) || [];
+  const packPubkeys = pack.profiles.map(p => p.pubkey);
+  const alreadyFollowingCount = packPubkeys.filter(pk => currentFollows.includes(pk)).length;
+  const isFullyFollowing = alreadyFollowingCount === packPubkeys.length && packPubkeys.length > 0;
+
+  const handleFollowPack = async () => {
+    if (!user) return;
+    
+    setIsFollowing(true);
+
+    // Get existing follows
+    const existingFollows = currentFollows;
+
+    // Add new follows from the pack (avoiding duplicates)
+    const newFollows = packPubkeys.filter(pk => !existingFollows.includes(pk));
+    
+    // Build the new follow list tags
+    const followTags = [
+      ...followList?.tags.filter(([name]) => name === 'p') || [],
+      ...newFollows.map(pubkey => {
+        const profile = pack.profiles.find(p => p.pubkey === pubkey);
+        return ['p', pubkey, profile?.relay || '', profile?.petname || ''] as [string, string, string, string];
+      })
+    ];
+
+    // Publish the updated follow list
+    publish(
+      {
+        kind: 3,
+        content: followList?.content || '',
+        tags: followTags,
+      },
+      {
+        onSuccess: () => {
+          setIsFollowing(false);
+        },
+        onError: () => {
+          setIsFollowing(false);
+        }
+      }
+    );
+  };
+
+  // Display up to 5 profile previews
+  const previewProfiles = pack.profiles.slice(0, 5);
+  const remainingCount = Math.max(0, pack.profiles.length - 5);
+
+  return (
+    <Card className="border-2 hover:shadow-lg transition-all h-full flex flex-col">
+      <CardHeader className="pb-3">
+        {pack.image && (
+          <div className="w-full h-32 mb-3 rounded-lg overflow-hidden bg-muted">
+            <img 
+              src={pack.image} 
+              alt={pack.title || 'Starter pack'} 
+              className="w-full h-full object-cover"
+            />
+          </div>
+        )}
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <CardTitle className="text-lg line-clamp-2">
+              {pack.title || 'Starter Pack'}
+            </CardTitle>
+            <CardDescription className="mt-1.5 line-clamp-2">
+              {pack.description || 'Eine kuratierte Liste empfohlener Profile zum Folgen'}
+            </CardDescription>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 mt-2">
+          <Badge variant="secondary" className="gap-1.5">
+            <Users className="h-3 w-3" />
+            {pack.profiles.length} {pack.profiles.length === 1 ? 'Profil' : 'Profile'}
+          </Badge>
+          {alreadyFollowingCount > 0 && (
+            <Badge variant="outline" className="gap-1.5 text-green-600 border-green-600">
+              <Check className="h-3 w-3" />
+              {alreadyFollowingCount} folgst du bereits
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      
+      <CardContent className="flex-1 flex flex-col gap-4">
+        {/* Profile Previews */}
+        <div className="space-y-2 flex-1">
+          {previewProfiles.map((profile) => (
+            <ProfilePreview 
+              key={profile.pubkey} 
+              pubkey={profile.pubkey} 
+              petname={profile.petname}
+            />
+          ))}
+          {remainingCount > 0 && (
+            <div className="text-sm text-muted-foreground pl-10">
+              und {remainingCount} weitere...
+            </div>
+          )}
+        </div>
+
+        {/* Follow Button */}
+        <Button
+          onClick={handleFollowPack}
+          disabled={!user || isPublishing || isFollowing || isFullyFollowing}
+          className="w-full"
+          variant={isFullyFollowing ? "outline" : "default"}
+        >
+          {isFullyFollowing ? (
+            <>
+              <Check className="h-4 w-4 mr-2" />
+              Folgst du bereits
+            </>
+          ) : isPublishing || isFollowing ? (
+            <>Wird aktualisiert...</>
+          ) : (
+            <>
+              <UserPlus className="h-4 w-4 mr-2" />
+              Allen folgen
+            </>
+          )}
+        </Button>
+
+        {!user && (
+          <p className="text-xs text-center text-muted-foreground">
+            Melde dich an, um diesem Pack zu folgen
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/StarterPacksSection.tsx
+++ b/src/components/StarterPacksSection.tsx
@@ -1,0 +1,92 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StarterPackCard } from "@/components/StarterPackCard";
+import { useStarterPacks } from "@/hooks/useStarterPacks";
+import { Users } from "lucide-react";
+
+function StarterPackSkeleton() {
+  return (
+    <Card className="border-2 h-full">
+      <div className="p-6 space-y-4">
+        {/* Image skeleton */}
+        <Skeleton className="w-full h-32 rounded-lg" />
+        
+        {/* Title and description */}
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-3/4" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+
+        {/* Badge */}
+        <Skeleton className="h-6 w-24" />
+
+        {/* Profile previews */}
+        <div className="space-y-2 pt-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex items-center gap-2">
+              <Skeleton className="h-8 w-8 rounded-full" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          ))}
+        </div>
+
+        {/* Button skeleton */}
+        <Skeleton className="h-10 w-full" />
+      </div>
+    </Card>
+  );
+}
+
+export function StarterPacksSection() {
+  const { data: starterPacks, isLoading, isError } = useStarterPacks();
+
+  // Don't show section if there are no packs and loading is complete
+  if (!isLoading && (!starterPacks || starterPacks.length === 0)) {
+    return null;
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto mb-12">
+      <div className="mb-6">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="flex items-center justify-center p-2 bg-gradient-to-r from-green-100 to-blue-100 dark:from-green-900/30 dark:to-blue-900/30 rounded-lg">
+            <Users className="h-6 w-6 text-green-600" />
+          </div>
+          <h2 className="text-2xl font-bold">Empfohlene Starter Packs</h2>
+        </div>
+        <p className="text-muted-foreground">
+          Folge kuratierten Listen interessanter Profile, um schnell loszulegen
+        </p>
+      </div>
+
+      {isError && (
+        <Card className="border-dashed">
+          <CardContent className="py-12 px-8 text-center">
+            <div className="max-w-sm mx-auto space-y-4">
+              <p className="text-muted-foreground">
+                Starter Packs konnten nicht geladen werden. Bitte versuche es später erneut.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {isLoading && (
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <StarterPackSkeleton key={i} />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && starterPacks && starterPacks.length > 0 && (
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {starterPacks.map((pack) => (
+            <StarterPackCard key={pack.event.id} pack={pack} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useStarterPacks.ts
+++ b/src/hooks/useStarterPacks.ts
@@ -1,0 +1,92 @@
+import { type NostrEvent } from '@nostrify/nostrify';
+import { useNostr } from '@nostrify/react';
+import { useQuery } from '@tanstack/react-query';
+
+// Hardcoded starter pack identifiers - these can be configured per deployment
+const STARTER_PACK_IDENTIFIERS = [
+  // https://following.space/d/p9ny0auxlpoa?p=d6d214fe27fcc0a691dd0f04d152b7cdda7f61f96f26dc421df46af0bb51792e
+  {
+    kind: 39089,
+    pubkey: 'd6d214fe27fcc0a691dd0f04d152b7cdda7f61f96f26dc421df46af0bb51792e', // Example (Freie Bildungsflotte)
+    identifier: 'p9ny0auxlpoa',
+  },
+];
+
+export interface StarterPackProfile {
+  pubkey: string;
+  relay?: string;
+  petname?: string;
+}
+
+export interface StarterPack {
+  event: NostrEvent;
+  identifier: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  profiles: StarterPackProfile[];
+}
+
+/**
+ * Hook to fetch NIP-51 starter packs (kind 39089)
+ * Starter packs are named sets of profiles to be followed together
+ */
+export function useStarterPacks() {
+  const { nostr } = useNostr();
+
+  return useQuery<StarterPack[]>({
+    queryKey: ['starter-packs', STARTER_PACK_IDENTIFIERS],
+    queryFn: async ({ signal }) => {
+      const timeoutSignal = AbortSignal.timeout(3000);
+      const combinedSignal = AbortSignal.any([signal, timeoutSignal]);
+
+      // Build filters for all starter packs
+      const filters = STARTER_PACK_IDENTIFIERS.map((pack) => ({
+        kinds: [pack.kind],
+        authors: [pack.pubkey],
+        '#d': [pack.identifier],
+        limit: 1,
+      }));
+
+      // Query all starter packs at once
+      const events = await nostr.query(filters, { signal: combinedSignal });
+
+      // Parse each event into a StarterPack object
+      const starterPacks: StarterPack[] = events
+        .map((event): StarterPack | null => {
+          // Extract d tag (identifier)
+          const dTag = event.tags.find(([name]) => name === 'd')?.[1];
+          if (!dTag) return null;
+
+          // Extract optional metadata tags
+          const title = event.tags.find(([name]) => name === 'title')?.[1];
+          const description = event.tags.find(([name]) => name === 'description')?.[1];
+          const image = event.tags.find(([name]) => name === 'image')?.[1];
+
+          // Extract profile tags (p tags)
+          const profiles: StarterPackProfile[] = event.tags
+            .filter(([name]) => name === 'p')
+            .map(([, pubkey, relay, petname]) => ({
+              pubkey,
+              relay,
+              petname,
+            }))
+            .filter((profile) => profile.pubkey); // Ensure pubkey exists
+
+          return {
+            event,
+            identifier: dTag,
+            title,
+            description,
+            image,
+            profiles,
+          };
+        })
+        .filter((pack): pack is StarterPack => pack !== null);
+
+      return starterPacks;
+    },
+    staleTime: 10 * 60 * 1000, // Cache for 10 minutes
+    retry: 2,
+  });
+}

--- a/src/pages/UserDashboardPage.tsx
+++ b/src/pages/UserDashboardPage.tsx
@@ -5,6 +5,7 @@ import { Moon, Sun, User, MessageSquare, Calendar, Wallet, Heart, Users, Trendin
 import { Link } from "react-router-dom";
 import { useSeoMeta } from '@unhead/react';
 import { EditProfileForm } from "@/components/EditProfileForm";
+import { StarterPacksSection } from "@/components/StarterPacksSection";
 import { useState } from "react";
 
 export default function UserDashboardPage() {
@@ -113,6 +114,9 @@ export default function UserDashboardPage() {
             Jetzt können Sie die dezentrale Welt erkunden!
           </p>
         </div>
+
+        {/* Starter Packs Section */}
+        <StarterPacksSection />
 
         {/* Profile Form Section */}
         {showProfileForm && (


### PR DESCRIPTION
This pull request introduces a new "Starter Packs" feature, allowing users to quickly follow curated sets of recommended profiles. The implementation includes a custom React hook for fetching starter packs, new UI components for displaying them, and integration into the user dashboard page. The changes are grouped into feature implementation, UI integration, and supporting hooks.

**Feature Implementation:**

* Added `StarterPackCard` and `StarterPacksSection` components to display curated lists of profiles users can follow, including profile previews, metadata, and a one-click follow button. [[1]](diffhunk://#diff-28cb253bf4bff70c59ff2d0399def1a5204734ac8136d24904f87d7247e1e7f0R1-R198) [[2]](diffhunk://#diff-70992dae9ddb7415423df2120531e93aba0514d05163e9e4fdf0bd0678584305R1-R92)

**Supporting Hooks:**

* Implemented the `useStarterPacks` hook to fetch starter packs using NIP-51 (kind 39089), parsing metadata and profile tags from events. Packs are identified by hardcoded identifiers for now.

**UI Integration:**

* Integrated the new `StarterPacksSection` into the `UserDashboardPage`, so users see recommended starter packs when viewing their dashboard. [[1]](diffhunk://#diff-22deebb2c8376bc0b3a102a97f376e401781676d0c773fc1bcf1687bc3d54089R8) [[2]](diffhunk://#diff-22deebb2c8376bc0b3a102a97f376e401781676d0c773fc1bcf1687bc3d54089R118-R120)