### PR TITLE
Add Settings Page and integrate into routing

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -12,6 +12,7 @@ import NotesPage from "./pages/NotesPage";
 import KanbansPage from "./pages/KanbansPage";
 import KanbanDetailPage from "./pages/KanbanDetailPage";
 import { NIP19Page } from "./pages/NIP19Page";
+import { SettingsPage } from "./pages/SettingsPage";
 import NotFound from "./pages/NotFound";
 
 export function AppRouter() {
@@ -29,6 +30,7 @@ export function AppRouter() {
         <Route path="/notes" element={<NotesPage />} />
         <Route path="/kanbans" element={<KanbansPage />} />
         <Route path="/kanban/:id" element={<KanbanDetailPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
         {/* NIP-19 route for npub1, note1, naddr1, nevent1, nprofile1 */}
         <Route path="/:nip19" element={<NIP19Page />} />
         {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -1,7 +1,8 @@
 // NOTE: This file is stable and usually should not be modified.
 // It is important that all functionality in this file is preserved, and should only be modified if explicitly requested.
 
-import { ChevronDown, LogOut, UserIcon, UserPlus, Wallet } from 'lucide-react';
+import { ChevronDown, LogOut, Settings as SettingsIcon, UserIcon, UserPlus, Wallet } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,6 +21,7 @@ interface AccountSwitcherProps {
 
 export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
   const { currentUser, otherUsers, setLogin, removeLogin } = useLoggedInAccounts();
+  const navigate = useNavigate();
 
   if (!currentUser) return null;
 
@@ -60,6 +62,13 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
           </DropdownMenuItem>
         ))}
         <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => navigate('/settings')}
+          className='flex items-center gap-2 cursor-pointer p-2 rounded-md'
+        >
+          <SettingsIcon className='w-4 h-4' />
+          <span>Settings</span>
+        </DropdownMenuItem>
         <WalletModal>
           <DropdownMenuItem
             className='flex items-center gap-2 cursor-pointer p-2 rounded-md'

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,0 +1,25 @@
+import { PageHeader } from '@/components/PageHeader';
+import { RelayListManager } from '@/components/RelayListManager';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export function SettingsPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
+      <PageHeader />
+
+      <div className="container max-w-4xl mx-auto px-4 py-20">
+        <Card>
+          <CardHeader>
+            <CardTitle>Relay Settings</CardTitle>
+            <CardDescription>
+              Manage your Nostr relay connections. Relays are used to read and write events on the Nostr network.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <RelayListManager />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request adds a new Settings page to the application and integrates it into the navigation and routing. The changes include creating the `SettingsPage` component, updating the app router to support the new route, and adding a Settings option to the account switcher dropdown.

**New Settings page integration:**

* Created the `SettingsPage` component with a UI for managing Nostr relay connections, including a header and relay list manager. (`src/pages/SettingsPage.tsx`)
* Added the `/settings` route to the app router and imported the new page. (`src/AppRouter.tsx`) [[1]](diffhunk://#diff-0dc0385e67910f0a3ca37b56d649a2e2cfc338c8c3915133cdaa225d03b627edR15) [[2]](diffhunk://#diff-0dc0385e67910f0a3ca37b56d649a2e2cfc338c8c3915133cdaa225d03b627edR33)

**Navigation updates:**

* Added a Settings option (with icon) to the account switcher dropdown, allowing users to navigate to the new Settings page. (`src/components/auth/AccountSwitcher.tsx`) [[1]](diffhunk://#diff-321105a518ae54a509ff8bdf0d438387adbfba3158c1b165407e1039507975a0L4-R5) [[2]](diffhunk://#diff-321105a518ae54a509ff8bdf0d438387adbfba3158c1b165407e1039507975a0R24) [[3]](diffhunk://#diff-321105a518ae54a509ff8bdf0d438387adbfba3158c1b165407e1039507975a0R65-R71)