### PR TITLE
Add dedicated Starter Packs Page

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -9,6 +9,7 @@ import PlatformDashboardPage from "./pages/PlatformDashboardPage";
 import UserDashboardPage from "./pages/UserDashboardPage";
 import EditProfilePage from "./pages/EditProfilePage";
 import NotesPage from "./pages/NotesPage";
+import StarterPacksPage from "./pages/StarterPacksPage";
 import KanbansPage from "./pages/KanbansPage";
 import KanbanDetailPage from "./pages/KanbanDetailPage";
 import { NIP19Page } from "./pages/NIP19Page";
@@ -28,6 +29,7 @@ export function AppRouter() {
         <Route path="/user-dashboard" element={<UserDashboardPage />} />
         <Route path="/edit-profile" element={<EditProfilePage />} />
         <Route path="/notes" element={<NotesPage />} />
+        <Route path="/starter-packs" element={<StarterPacksPage />} />
         <Route path="/kanbans" element={<KanbansPage />} />
         <Route path="/kanban/:id" element={<KanbanDetailPage />} />
         <Route path="/settings" element={<SettingsPage />} />

--- a/src/hooks/useAllStarterPacks.ts
+++ b/src/hooks/useAllStarterPacks.ts
@@ -1,0 +1,82 @@
+import { type NostrEvent } from '@nostrify/nostrify';
+import { useNostr } from '@nostrify/react';
+import { useQuery } from '@tanstack/react-query';
+
+export interface StarterPackProfile {
+  pubkey: string;
+  relay?: string;
+  petname?: string;
+}
+
+export interface StarterPack {
+  event: NostrEvent;
+  identifier: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  profiles: StarterPackProfile[];
+}
+
+/**
+ * Hook to fetch all NIP-51 starter packs (kind 39089) available on the network
+ * This queries all starter packs without filtering by specific identifiers
+ */
+export function useAllStarterPacks() {
+  const { nostr } = useNostr();
+
+  return useQuery<StarterPack[]>({
+    queryKey: ['all-starter-packs'],
+    queryFn: async ({ signal }) => {
+      const timeoutSignal = AbortSignal.timeout(3000);
+      const combinedSignal = AbortSignal.any([signal, timeoutSignal]);
+
+      // Query all starter packs (kind 39089) without filtering by author
+      const events = await nostr.query(
+        [
+          {
+            kinds: [39089],
+            limit: 50,
+          },
+        ],
+        { signal: combinedSignal }
+      );
+
+      // Parse each event into a StarterPack object
+      const starterPacks: StarterPack[] = events
+        .map((event): StarterPack | null => {
+          // Extract d tag (identifier)
+          const dTag = event.tags.find(([name]) => name === 'd')?.[1];
+          if (!dTag) return null;
+
+          // Extract optional metadata tags
+          const title = event.tags.find(([name]) => name === 'title')?.[1];
+          const description = event.tags.find(([name]) => name === 'description')?.[1];
+          const image = event.tags.find(([name]) => name === 'image')?.[1];
+
+          // Extract profile tags (p tags)
+          const profiles: StarterPackProfile[] = event.tags
+            .filter(([name]) => name === 'p')
+            .map(([, pubkey, relay, petname]) => ({
+              pubkey,
+              relay,
+              petname,
+            }))
+            .filter((profile) => profile.pubkey); // Ensure pubkey exists
+
+          return {
+            event,
+            identifier: dTag,
+            title,
+            description,
+            image,
+            profiles,
+          };
+        })
+        .filter((pack): pack is StarterPack => pack !== null);
+
+      return starterPacks;
+    },
+    staleTime: 10 * 60 * 1000, // Cache for 10 minutes
+    retry: 2,
+  });
+}

--- a/src/pages/StarterPacksPage.tsx
+++ b/src/pages/StarterPacksPage.tsx
@@ -1,0 +1,118 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StarterPackCard } from "@/components/StarterPackCard";
+import { useAllStarterPacks } from "@/hooks/useAllStarterPacks";
+import { Users } from "lucide-react";
+import { useSeoMeta } from '@unhead/react';
+import { PageHeader } from "@/components/PageHeader";
+
+function StarterPackSkeleton() {
+  return (
+    <Card className="border-2 h-full">
+      <div className="p-6 space-y-4">
+        {/* Image skeleton */}
+        <Skeleton className="w-full h-32 rounded-lg" />
+        
+        {/* Title and description */}
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-3/4" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+
+        {/* Badge */}
+        <Skeleton className="h-6 w-24" />
+
+        {/* Profile previews */}
+        <div className="space-y-2 pt-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex items-center gap-2">
+              <Skeleton className="h-8 w-8 rounded-full" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          ))}
+        </div>
+
+        {/* Button skeleton */}
+        <Skeleton className="h-10 w-full" />
+      </div>
+    </Card>
+  );
+}
+
+export default function StarterPacksPage() {
+  const {
+    data: starterPacks,
+    isLoading: isLoadingPacks,
+    isError: isPacksError,
+  } = useAllStarterPacks();
+
+  useSeoMeta({
+    title: 'Browse Starter Packs - Nostr Onboarding',
+    description: 'Explore curated lists of interesting profiles to follow on Nostr',
+  });
+
+  return (
+    <div className="min-h-screen bg-background">
+      <PageHeader />
+
+      <div className="container mx-auto px-4 py-20">
+        {/* Header */}
+        <div className="max-w-4xl mx-auto text-center space-y-6 mb-12">
+          <div className="inline-flex items-center justify-center p-3 bg-gradient-to-r from-green-100 to-blue-100 dark:from-green-900/30 dark:to-blue-900/30 rounded-full">
+            <Users className="h-12 w-12 text-green-600" />
+          </div>
+          <h1 className="text-4xl lg:text-5xl font-bold tracking-tight">
+            Entdecke Starter Packs
+          </h1>
+          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+            Folge kuratierten Listen interessanter Profile, um schnell loszulegen und die Nostr-Community zu entdecken
+          </p>
+        </div>
+
+        {/* Content */}
+        <div className="max-w-6xl mx-auto">
+          {isPacksError && (
+            <Card className="border-dashed">
+              <CardContent className="py-12 px-8 text-center">
+                <div className="max-w-sm mx-auto space-y-4">
+                  <p className="text-muted-foreground">
+                    Starter Packs konnten nicht geladen werden. Bitte überprüfe deine Relay-Verbindungen oder versuche es später erneut.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {isLoadingPacks && (
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {[1, 2, 3, 4, 5, 6].map((i) => (
+                <StarterPackSkeleton key={`pack-skeleton-${i}`} />
+              ))}
+            </div>
+          )}
+
+          {!isLoadingPacks && starterPacks && starterPacks.length > 0 && (
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {starterPacks.map((pack) => (
+                <StarterPackCard key={pack.event.id} pack={pack} />
+              ))}
+            </div>
+          )}
+
+          {!isLoadingPacks && starterPacks && starterPacks.length === 0 && (
+            <Card className="border-dashed">
+              <CardContent className="py-12 px-8 text-center">
+                <div className="max-w-sm mx-auto space-y-4">
+                  <p className="text-muted-foreground">
+                    Keine Starter Packs gefunden. Überprüfe deine Relay-Verbindungen oder warte einen Moment, bis Inhalte geladen werden.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/UserDashboardPage.tsx
+++ b/src/pages/UserDashboardPage.tsx
@@ -39,10 +39,10 @@ export default function UserDashboardPage() {
     },
     {
       icon: Users,
-      title: "Nutzer folgen",
-      description: "Finden Sie interessante Personen",
+      title: "Starter Packs folgen",
+      description: "Finden Sie interessante Personengruppen",
       color: "text-green-600",
-      href: "/users"
+      href: "/starter-packs"
     },
     {
       icon: Calendar,


### PR DESCRIPTION
This pull request introduces a new "Starter Packs" feature to the application, allowing users to browse curated lists of interesting profiles to follow. It adds a dedicated page for browsing starter packs, implements the data-fetching logic for these packs, and updates navigation and dashboard links to integrate the new feature.

**New Starter Packs Feature Integration:**

- Added a new route and import for `StarterPacksPage` in `AppRouter.tsx`, making the page accessible at `/starter-packs`. [[1]](diffhunk://#diff-0dc0385e67910f0a3ca37b56d649a2e2cfc338c8c3915133cdaa225d03b627edR12) [[2]](diffhunk://#diff-0dc0385e67910f0a3ca37b56d649a2e2cfc338c8c3915133cdaa225d03b627edR32)
- Created the `StarterPacksPage` with loading, error, and empty states, and integrated SEO metadata. The page displays starter packs using the new `StarterPackCard` component and a skeleton loader for improved UX.
- Implemented the `useAllStarterPacks` React hook to fetch NIP-51 starter packs (kind 39089) from the network, parse their metadata, and expose them to the UI with caching and retry logic.

**Navigation and Dashboard Updates:**

- Updated the user dashboard to link to the new "Starter Packs" page, changing the title and description to reflect the new feature.