### PR TITLE
Keycloak login tab

### DIFF
--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -338,13 +338,42 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
             </TabsContent>
 
             <TabsContent value='keycloak' className='space-y-3'>
-              <div className='text-center p-4 rounded-lg bg-muted/60 opacity-60'>
-                <Shield className='w-12 h-12 mx-auto mb-3 text-muted-foreground' />
-                <p className='text-sm text-muted-foreground mb-4'>
-                  KeyCloak-Login ist noch nicht implementiert.
-                </p>
+              <div className='p-4 rounded-lg bg-muted/60 opacity-60 space-y-4'>
+                <div className="text-center">
+                  <Shield className='w-12 h-12 mx-auto mb-3 text-muted-foreground' />
+                  <p className='text-sm text-muted-foreground'>
+                    KeyCloak-Login ist noch nicht implementiert.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="keycloak-email" className="text-sm font-medium">
+                    E-Mail
+                  </label>
+                  <Input
+                    id="keycloak-email"
+                    type="email"
+                    placeholder="name@firma.de"
+                    disabled
+                    autoComplete="off"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label htmlFor="keycloak-password" className="text-sm font-medium">
+                    Passwort
+                  </label>
+                  <Input
+                    id="keycloak-password"
+                    type="password"
+                    placeholder="••••••••"
+                    disabled
+                    autoComplete="off"
+                  />
+                </div>
+
                 <Button className='w-full rounded-full py-4' disabled>
-                  Kommt bald
+                  Anmelden
                 </Button>
               </div>
             </TabsContent>


### PR DESCRIPTION
This pull request updates the `LoginDialog` component to prepare for a future KeyCloak login option. The main focus is on adding a new KeyCloak tab to the login dialog, although the functionality is not yet implemented.

Authentication UI changes:

* Added a new "KeyCloak" tab to the login dialog by increasing the number of columns in the `TabsList` from 3 to 4 and adding a corresponding `TabsTrigger` for KeyCloak. [[1]](diffhunk://#diff-66dcd3f00d045fce3bb5e0c8569912382f6719669585595cc8fd2320a64fbb81L196-R196) [[2]](diffhunk://#diff-66dcd3f00d045fce3bb5e0c8569912382f6719669585595cc8fd2320a64fbb81R209-R212)
* Added a placeholder `TabsContent` for the KeyCloak login, including disabled input fields and a disabled login button, with a notice that KeyCloak login is not yet implemented.