### PR TITLE
Update Kanban Board link to external URL in UserDashboardPage

### DIFF
--- a/src/pages/UserDashboardPage.tsx
+++ b/src/pages/UserDashboardPage.tsx
@@ -49,7 +49,7 @@ export default function UserDashboardPage() {
       title: "Kanban Board",
       description: "Entdecken Sie Kanban Boards",
       color: "text-orange-600",
-      href: "/kanbans"
+      href: "https://edufeed-org.github.io/kanban-editor/cardsboard"
     }
   ];
 


### PR DESCRIPTION
This pull request makes a small update to the `UserDashboardPage` by changing the Kanban Board link to point to an external URL instead of an internal route.