### PR TITLE
Remove theme toggle button from EditProfilePage

### DIFF
--- a/src/pages/EditProfilePage.tsx
+++ b/src/pages/EditProfilePage.tsx
@@ -1,15 +1,12 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { EditProfileForm } from "@/components/EditProfileForm";
-import { useTheme } from "@/hooks/useTheme";
-import { Moon, Sun, ArrowLeft } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useSeoMeta } from '@unhead/react';
 import { PageHeader } from "@/components/PageHeader";
 
 export default function EditProfilePage() {
-  const { theme, setTheme } = useTheme();
-
   useSeoMeta({
     title: 'Profil bearbeiten - Nostr Onboarding',
     description: 'Bearbeiten Sie Ihr Nostr-Profil.',
@@ -17,20 +14,6 @@ export default function EditProfilePage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Theme Toggle */}
-      <div className="fixed top-6 right-6 z-50">
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => setTheme(theme === "light" ? "dark" : "light")}
-          className="rounded-full"
-        >
-          <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Theme wechseln</span>
-        </Button>
-      </div>
-
       <div className="container mx-auto px-4 py-20">
         <PageHeader />
 


### PR DESCRIPTION
This pull request simplifies the `EditProfilePage` by removing the theme toggle functionality and related imports. The page now focuses solely on profile editing without the option to switch between light and dark themes.

- UI Simplification:
  * Removed the theme toggle button and its associated logic from the page layout. (`src/pages/EditProfilePage.tsx`)

- Code Cleanup:
  * Deleted unused imports related to theme toggling (`useTheme`, `Moon`, and `Sun`). (`src/pages/EditProfilePage.tsx`)