### PR TITLE
Colors based on fOERbico color palette

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,89 +4,89 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* Light theme: tuned to fOERbico design palette */
+    --background: 0 0% 100%; /* #FFFFFF */
+    --foreground: 0 0% 20%; /* #333333 */
 
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 0 0% 20%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 0 0% 20%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    /* Primary: fOERbico deep blue (#203A8F) */
+    --primary: 226 64% 34%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    /* Secondary: Orange (#FFA500) */
+    --secondary: 39 100% 50%;
+    --secondary-foreground: 0 0% 6%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    /* Muted / subtle background (AliceBlue-ish #F0F8FF) */
+    --muted: 210 100% 97%;
+    --muted-foreground: 0 0% 20%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 226 64% 34%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    /* Borders / inputs: light gray (#D3D3D3) */
+    --border: 0 0% 83%;
+    --input: 0 0% 83%;
+    --ring: 226 64% 34%;
 
     --radius: 0.5rem;
 
-    --sidebar-background: 0 0% 98%;
-
-    --sidebar-foreground: 240 5.3% 26.1%;
-
-    --sidebar-primary: 240 5.9% 10%;
-
-    --sidebar-primary-foreground: 0 0% 98%;
-
-    --sidebar-accent: 240 4.8% 95.9%;
-
-    --sidebar-accent-foreground: 240 5.9% 10%;
-
-    --sidebar-border: 220 13% 91%;
-
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    /* Sidebar uses subtle blue-tinted backgrounds */
+    --sidebar-background: 210 100% 97%; /* #F0F8FF */
+    --sidebar-foreground: 0 0% 20%;
+    --sidebar-primary: 219 100% 20%; /* #002366 for headings */
+    --sidebar-primary-foreground: 0 0% 100%;
+    --sidebar-accent: 226 64% 34%;
+    --sidebar-accent-foreground: 0 0% 100%;
+    --sidebar-border: 0 0% 83%;
+    --sidebar-ring: 226 64% 34%;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
+    /* Dark theme: keep contrast while reflecting brand */
+    --background: 222.2 14% 6%;
+    --foreground: 0 0% 100%;
 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
+    --card: 222.2 14% 6%;
+    --card-foreground: 0 0% 100%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 222.2 14% 6%;
+    --popover-foreground: 0 0% 100%;
 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 226 64% 60%;
+    --primary-foreground: 0 0% 0%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 39 100% 50%;
+    --secondary-foreground: 0 0% 6%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 219 12% 17%;
+    --muted-foreground: 0 0% 70%;
 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 226 64% 50%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
+    --border: 219 12% 17%;
+    --input: 219 12% 17%;
+    --ring: 226 64% 60%;
+    --sidebar-background: 222.2 14% 8%;
+    --sidebar-foreground: 0 0% 100%;
+    --sidebar-primary: 219 100% 20%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-accent: 226 64% 50%;
+    --sidebar-accent-foreground: 0 0% 100%;
+    --sidebar-border: 219 12% 17%;
+    --sidebar-ring: 226 64% 60%;
   }
 }
 


### PR DESCRIPTION
This pull request updates the application's color palette in `src/index.css` to better align with the fOERbico brand and design guidelines. It introduces new HSL values for both light and dark themes, focusing on primary, secondary, muted, and sidebar colors, and adds detailed comments for clarity. The changes ensure improved visual consistency and accessibility across the application.

**Theme palette updates:**

* Updated the light theme color variables (e.g., `--primary`, `--secondary`, `--muted`, `--accent`, and sidebar-related variables) to use the fOERbico brand palette, with detailed inline comments for each color's purpose.
* Adjusted the dark theme color variables to maintain contrast and reflect the brand, including new values for primary, secondary, muted, accent, and sidebar colors.

**Code clarity:**

* Added descriptive comments to each color variable group, explaining the rationale and mapping to specific brand colors or design intentions.