### PR TITLE
Extension Hints on Login Form

### DIFF
--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -223,7 +223,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                 <p className='text-sm text-gray-600 dark:text-gray-300 mb-4'>
                   Mit einem Klick über die Browser-Erweiterung anmelden
                 </p>
-                <div className="flex justify-center">
+                <div className="flex justify-center mb-4">
                   <Button
                     className='w-full rounded-full py-4'
                     onClick={handleExtensionLogin}
@@ -232,6 +232,27 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                     {isLoading ? 'Anmeldung läuft...' : 'Mit Erweiterung anmelden'}
                   </Button>
                 </div>
+                <p className='text-xs text-gray-500 dark:text-gray-400'>
+                  Noch keine Erweiterung?{' '}
+                  <a
+                    href="https://keys.band"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:underline"
+                  >
+                    keys.band
+                  </a>
+                  {' oder '}
+                  <a
+                    href="https://getalby.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:underline"
+                  >
+                    Alby
+                  </a>
+                  {' installieren'}
+                </p>
               </div>
             </TabsContent>
 


### PR DESCRIPTION
This pull request makes a small improvement to the `LoginDialog` component by enhancing the user interface for users who do not yet have the required browser extension. It adds a helpful message with links to install the necessary extensions, and slightly adjusts spacing for better layout.

- **User Interface Enhancements:**
  * Added a message below the login button with links to `keys.band` and `Alby` for users who need to install a browser extension.
  * Added a bottom margin (`mb-4`) to the container holding the login button for improved spacing.